### PR TITLE
feat(300): implement sd-step and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+sd-step
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Thank you for considering contributing! There are many ways you can help.
+
+## Issues
+
+File an issue if you think you've found a bug. Be sure to describe
+
+1. How can it be reproduced?
+2. What did you expect?
+3. What actually occurred?
+4. Version, platform, etc. if possibly relevant.
+
+## Docs
+
+Documentation, READMEs, and examples are extremely important. Please help improve them and if you find a typo or notice a problem, please send a fix or say something.
+
+## Submitting Patches
+
+Patches for fixes, features, and improvements are accepted through pull requests.
+
+* Write good commit messages, in the present tense! (Add X, not Added X). Short title, blank line, bullet points if needed. Capitalize the first letter of the title or bullet item. No punctuation in the title.
+* Code must pass lint and style checks.
+* All external methods must be documented.
+* Include tests to improve coverage and prevent regressions.
+* Squash changes into a single commit per feature/fix. Ask if you're unsure how to discretize your work.
+
+Please ask before embarking on a large improvement so you're not disappointed if it does not align with the goals of the project or owner(s).
+
+## Commit message format
+
+To be consistent, we require commit messages to be in this specific format: `<type>(<scope>): <subject>`
+
+* Types:
+  * feat (feature)
+  * fix (bug fix)
+  * docs (documentation)
+  * style (formatting, missing semi colons, …)
+  * refactor
+  * test (when adding missing tests)
+  * chore (maintain)
+* Scope: anything that specifies the scope of the commit. Can be blank or `*`
+* Subject: description of the commit. For **breaking changes** that require major version bump, add `BREAKING CHANGE` to the commit message.
+
+**Examples commit messages:**
+* Bug fix: `fix: Remove extra space`
+* Breaking change: `feat(scm): Support new scm plugin. BREAKING CHANGE: github no longer works`
+
+## Feature Requests
+
+Make the case for a feature via an issue with a good title. The feature should be discussed and given a target inclusion milestone or closed.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright 2017 Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,33 @@
+workflow:
+    - deploy
+
+shared:
+    image: golang
+    environment:
+        GOPATH: /sd/workspace
+
+jobs:
+    main:
+        steps:
+            - get: go get -t ./...
+            - vet: go vet ./...
+            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - test: go test ./...
+            - build: go build -a -o sd-step
+
+    deploy:
+        steps:
+            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - get: go get -t ./...
+            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - build: go build -a -o sd-step
+            - get-bzip2: apt-get update && apt-get install -y --no-install-recommends bzip2
+            - tag: ./ci/git-tag.sh
+            - release: ./ci/git-release.sh
+        secrets:
+            # Pushing tags to Git
+            - GIT_KEY
+            # Pushing releases to GitHub
+            - GITHUB_TOKEN
+        environment:
+            RELEASE_FILE: sd-step

--- a/sd-step.go
+++ b/sd-step.go
@@ -65,13 +65,12 @@ func runCommand(command string, output io.Writer) error {
 
 // execHab installs habitat package and executes habitat command
 func execHab(pkgName string, pkgVersion string, command []string, output io.Writer) error {
-	var installCmd []string
 	pkg, verErr := translatePkgName(pkgName, pkgVersion)
 	if verErr != nil {
 		return verErr
 	}
 
-	installCmd = []string{habPath, "pkg", "install", pkg}
+	installCmd := []string{habPath, "pkg", "install", pkg}
 	unwrappedInstallCommand := strings.Join(installCmd, " ")
 	installErr := runCommand(unwrappedInstallCommand, output)
 	if installErr != nil {

--- a/sd-step.go
+++ b/sd-step.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime/debug"
+	"strings"
+
+	"github.com/urfave/cli"
+)
+
+// VERSION gets set by the build script via the LDFLAGS
+var VERSION string
+
+var habPath = "/opt/sd/bin/hab"
+var versionValidator = regexp.MustCompile(`^\d+(\.\d+)*$`)
+var fprintf = fmt.Fprintf
+var execCommand = exec.Command
+
+// finalRecover makes one last attempt to recover from a panic.
+// This should only happen if the previous recovery caused a panic.
+func finalRecover() {
+	if p := recover(); p != nil {
+		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
+		failureExit(nil)
+	}
+	successExit()
+}
+
+// successExit exits process with 0
+func successExit() {
+	os.Exit(0)
+}
+
+// failureExit exits process with 1
+func failureExit(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+	}
+	os.Exit(1)
+}
+
+// translatePkgName translates the pkgName if pkgVersion is specified
+func translatePkgName(pkgName string, pkgVersion string) (string, error) {
+	if pkgVersion == "" {
+		return pkgName, nil
+	} else if valid := versionValidator.MatchString(pkgVersion); valid == true {
+		return pkgName + "/" + pkgVersion, nil
+	} else {
+		return "", fmt.Errorf("%v is invalid version", pkgVersion)
+	}
+}
+
+// runCommand runs command
+func runCommand(command string, output io.Writer) error {
+	cmd := execCommand("sh", "-c", command)
+	cmd.Stdout = output
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// execHab installs habitat package and executes habitat command
+func execHab(pkgName string, pkgVersion string, command []string, output io.Writer) error {
+	var installCmd []string
+	pkg, verErr := translatePkgName(pkgName, pkgVersion)
+	if verErr != nil {
+		return verErr
+	}
+
+	installCmd = []string{habPath, "pkg", "install", pkg}
+	unwrappedInstallCommand := strings.Join(installCmd, " ")
+	installErr := runCommand(unwrappedInstallCommand, output)
+	if installErr != nil {
+		return installErr
+	}
+
+	execCmd := []string{habPath, "pkg", "exec", pkg}
+	unwrappedExecCommand := strings.Join(append(execCmd, command...), " ")
+	execErr := runCommand(unwrappedExecCommand, output)
+	if execErr != nil {
+		return execErr
+	}
+
+	return nil
+}
+
+func main() {
+	defer finalRecover()
+
+	var pkgVersion string
+
+	app := cli.NewApp()
+	app.Name = "sd-step"
+	app.Usage = "wrapper command of habitat for Screwdriver"
+	app.UsageText = "sd-step command arguments [options]"
+	app.Copyright = "(c) 2017 Yahoo Inc."
+
+	if VERSION == "" {
+		VERSION = "0.0.0"
+	}
+	app.Version = VERSION
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:        "pkg-version",
+			Usage:       "Package version",
+			Value:       "",
+			Destination: &pkgVersion,
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:  "exec",
+			Usage: "Install and exec habitat package with pkg_name and command...",
+			Action: func(c *cli.Context) error {
+				if len(c.Args()) < 2 {
+					return cli.ShowAppHelp(c)
+				}
+				err := execHab(c.Args().Get(0), pkgVersion, c.Args().Tail(), os.Stdout)
+				if err != nil {
+					failureExit(err)
+				}
+				successExit()
+				return nil
+			},
+			Flags: app.Flags,
+		},
+	}
+
+	app.Run(os.Args)
+}

--- a/sd-step.go
+++ b/sd-step.go
@@ -17,19 +17,7 @@ var VERSION string
 
 var habPath = "/opt/sd/bin/hab"
 var versionValidator = regexp.MustCompile(`^\d+(\.\d+)*$`)
-var fprintf = fmt.Fprintf
 var execCommand = exec.Command
-
-// finalRecover makes one last attempt to recover from a panic.
-// This should only happen if the previous recovery caused a panic.
-func finalRecover() {
-	if p := recover(); p != nil {
-		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
-		failureExit(nil)
-	}
-	successExit()
-}
 
 // successExit exits process with 0
 func successExit() {
@@ -42,6 +30,17 @@ func failureExit(err error) {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 	}
 	os.Exit(1)
+}
+
+// finalRecover makes one last attempt to recover from a panic.
+// This should only happen if the previous recovery caused a panic.
+func finalRecover() {
+	if p := recover(); p != nil {
+		fmt.Fprintln(os.Stderr, "ERROR: Something terrible has happened. Please file a ticket with this info:")
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n%v\n", p, debug.Stack())
+		failureExit(nil)
+	}
+	successExit()
 }
 
 // translatePkgName translates the pkgName if pkgVersion is specified

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -26,7 +26,7 @@ func TestRunCommand(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	err := runCommand("hab pkg install foo/bar", stdout)
 	expected := "run hab pkg install\n"
-	if string(stdout.Bytes()) != expected {
+	if err != nil {
 		t.Errorf("runCommand error = %q, should be nil", err)
 	}
 	if string(stdout.Bytes()) != expected {

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func fakeExecCommand(command string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, args...)
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+const habExecResult = "run hab pkg install\nrun hab pkg exec\n"
+
+func TestRunCommand(t *testing.T) {
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+
+	stdout := new(bytes.Buffer)
+	err := runCommand("hab pkg install foo/bar", stdout)
+	expected := "run hab pkg install\n"
+	if string(stdout.Bytes()) != expected {
+		t.Errorf("runCommand error = %q, should be nil", err)
+	}
+	if string(stdout.Bytes()) != expected {
+		t.Errorf("Expected '%v', actual '%v'", expected, string(stdout.Bytes()))
+	}
+
+	stdout = new(bytes.Buffer)
+	err = runCommand("hab pkg exec foo/bar foo bar foobar", stdout)
+	expected = "run hab pkg exec\n"
+	if err != nil {
+		t.Errorf("runCommand error = %v, should be nil", err)
+	}
+	if string(stdout.Bytes()) != expected {
+		t.Errorf("Expected '%v', actual '%v'", expected, string(stdout.Bytes()))
+	}
+}
+
+func TestExecHab(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	execCommand = fakeExecCommand
+	defer func() { execCommand = exec.Command }()
+	err := execHab("foo/bar", "2.2.2", []string{"foo", "bar", "foobar"}, stdout)
+	if err != nil {
+		t.Errorf("execHab error = %q, should be nil", err)
+	}
+	if string(stdout.Bytes()) != habExecResult {
+		t.Errorf("Expected %q, got %q", habExecResult, string(stdout.Bytes()))
+	}
+}
+
+func TestMain(m *testing.M) {
+	retCode := m.Run()
+	os.Exit(retCode)
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+	args := os.Args[:]
+	for i, val := range os.Args {
+		args = os.Args[i:]
+		if val == "-c" {
+			args = strings.Split(args[1:][0], " ")
+			break
+		}
+	}
+	if len(args) >= 4 && args[1] == "pkg" {
+		switch args[2] {
+		case "install":
+			fmt.Println("run hab pkg install")
+			return
+		case "exec":
+			fmt.Println("run hab pkg exec")
+			return
+		default:
+			os.Exit(255)
+		}
+	}
+	os.Exit(255)
+}


### PR DESCRIPTION
To enable users to run 2 `hab` commands in 1 command, `sd-step` wraps `hab` commands.
`sd-step` receives "exec", $package_name, and $commands... as arguments, and $package_version as an option. 
Then, run 2 `hab` commands, `hab pkg install $package_name(/$package_version)` and `hab pkg exec $package_name(/$package_version) $commands...`.


Detail is https://github.com/screwdriver-cd/screwdriver/issues/300 .
Based on https://github.com/screwdriver-cd/screwdriver/issues/300 , this PR implements `sd-step` which wraps `hab` commands.
This PR only handle the exact version because handling semver for `hab` package version is a task for next pass.

This works like following:
```
$ go build
$ sd-step exec core/git git clone https://github.com/screwdriver-cd/sd-step.git --pkg-version 2.7.4
» Installing core/git/2.7.4

...

✓ Installed core/git/2.7.4/20160729215550
★ Install of core/git/2.7.4/20160729215550 complete with 24 new packages installed.
Cloning into 'sd-step'...
remote: Counting objects: 3, done.
remote: Total 3 (delta 0), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (3/3), done.
Checking connectivity... done.
```