### PR TITLE
fix(300): redirect install output to /dev/null

### DIFF
--- a/sd-step.go
+++ b/sd-step.go
@@ -69,7 +69,7 @@ func execHab(pkgName string, pkgVersion string, command []string, output io.Writ
 		return verErr
 	}
 
-	installCmd := []string{habPath, "pkg", "install", pkg, "1>/dev/null"}
+	installCmd := []string{habPath, "pkg", "install", pkg, ">/dev/null"}
 	unwrappedInstallCommand := strings.Join(installCmd, " ")
 	installErr := runCommand(unwrappedInstallCommand, output)
 	if installErr != nil {

--- a/sd-step.go
+++ b/sd-step.go
@@ -69,7 +69,7 @@ func execHab(pkgName string, pkgVersion string, command []string, output io.Writ
 		return verErr
 	}
 
-	installCmd := []string{habPath, "pkg", "install", pkg}
+	installCmd := []string{habPath, "pkg", "install", pkg, "1>/dev/null"}
 	unwrappedInstallCommand := strings.Join(installCmd, " ")
 	installErr := runCommand(unwrappedInstallCommand, output)
 	if installErr != nil {


### PR DESCRIPTION
By default, `sd-step exec foo bar` outputs download progress in one line.
![2017-04-14 9 57 24](https://cloud.githubusercontent.com/assets/8113204/25031493/46ff0b1a-2108-11e7-8f63-404049796f78.png)

However, if large size packages will being downloaded, download progress output will be very long and an error will be occurred because of bufio.Scanner's limit. 
```
Error running launcher: Error with scanner: bufio.Scanner: token too long
```
To avoid this situation, sd-step redirects `hab pkg install`'s standard output to /dev/null.

Related issue: https://github.com/screwdriver-cd/screwdriver/issues/525