### PR TITLE
feat(300): support semver feature

### DIFF
--- a/hab/hab.go
+++ b/hab/hab.go
@@ -8,6 +8,7 @@ import (
 	"time"
 )
 
+// The pkgs respose from depot
 type PackagesInfo struct {
 	RangeStart  int           `json:"range_start"`
 	RangeEnd    int           `json:"range_end"`
@@ -15,6 +16,7 @@ type PackagesInfo struct {
 	PackageList []PackageInfo `json:"package_list"`
 }
 
+// The package info in pkgs response
 type PackageInfo struct {
 	Origin  string `json:"origin"`
 	Name    string `json:"name"`
@@ -22,6 +24,7 @@ type PackageInfo struct {
 	Release string `json:"release"`
 }
 
+// The depot for hab
 type Depot interface {
 	PackageVersionsFromName(pkgName string) ([]string, error)
 }
@@ -31,10 +34,12 @@ type depot struct {
 	client  *http.Client
 }
 
+// New returns a new depot object
 func New(baseURL string) *depot {
 	return &depot{baseURL, &http.Client{Timeout: 10 * time.Second}}
 }
 
+// packagesInfo fetch packages info from depot
 func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) {
 	pkgUrl := fmt.Sprintf("%s/pkgs/%s?range=%d", depo.baseURL, pkgName, from)
 	res, err := depo.client.Get(pkgUrl)
@@ -47,9 +52,7 @@ func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) 
 
 	if res.StatusCode == 404 {
 		return PackagesInfo{}, errors.New("Package not found")
-	}
-
-	if res.StatusCode != 200 {
+	} else if res.StatusCode != 200 {
 		return PackagesInfo{}, errors.New(fmt.Sprintf("Unexpected status code: %d", res.StatusCode))
 	}
 
@@ -59,6 +62,7 @@ func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) 
 	return pkgsInfo, nil
 }
 
+// PackageVersionsFromName fetch all versions from depot
 func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
 	var packages []PackageInfo
 
@@ -76,7 +80,7 @@ func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
 			break
 		}
 
-		offset += pkgsInfo.RangeEnd - pkgsInfo.RangeStart
+		offset = pkgsInfo.RangeEnd
 	}
 
 	var versions []string

--- a/hab/hab.go
+++ b/hab/hab.go
@@ -88,8 +88,13 @@ func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
 	}
 
 	var versions []string
+	foundVersions := map[string]bool{}
 	for _, pkg := range packages {
+		if _, ok := foundVersions[pkg.Version]; ok {
+			continue
+		}
 		versions = append(versions, pkg.Version)
+		foundVersions[pkg.Version] = true
 	}
 
 	return versions, nil

--- a/hab/hab.go
+++ b/hab/hab.go
@@ -80,11 +80,11 @@ func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
 
 		packages = append(packages, pkgsInfo.PackageList...)
 
-		if pkgsInfo.RangeEnd+1 >= pkgsInfo.TotalCount {
+		offset = pkgsInfo.RangeEnd + 1
+
+		if offset >= pkgsInfo.TotalCount {
 			break
 		}
-
-		offset = pkgsInfo.RangeEnd
 	}
 
 	var versions []string

--- a/hab/hab.go
+++ b/hab/hab.go
@@ -90,7 +90,7 @@ func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
 	var versions []string
 	foundVersions := map[string]bool{}
 	for _, pkg := range packages {
-		if _, ok := foundVersions[pkg.Version]; ok {
+		if foundVersions[pkg.Version] {
 			continue
 		}
 		versions = append(versions, pkg.Version)

--- a/hab/hab.go
+++ b/hab/hab.go
@@ -1,0 +1,88 @@
+package hab
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type PackagesInfo struct {
+	RangeStart  int           `json:"range_start"`
+	RangeEnd    int           `json:"range_end"`
+	TotalCount  int           `json:"total_count"`
+	PackageList []PackageInfo `json:"package_list"`
+}
+
+type PackageInfo struct {
+	Origin  string `json:"origin"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Release string `json:"release"`
+}
+
+type Depot interface {
+	PackageVersionsFromName(pkgName string) ([]string, error)
+}
+
+type depot struct {
+	baseURL string
+	client  *http.Client
+}
+
+func New(baseURL string) *depot {
+	return &depot{baseURL, &http.Client{Timeout: 10 * time.Second}}
+}
+
+func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) {
+	pkgUrl := fmt.Sprintf("%s/pkgs/%s?range=%d", depo.baseURL, pkgName, from)
+	res, err := depo.client.Get(pkgUrl)
+
+	if err != nil {
+		return PackagesInfo{}, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode == 404 {
+		return PackagesInfo{}, errors.New("Package not found")
+	}
+
+	if res.StatusCode != 200 {
+		return PackagesInfo{}, errors.New(fmt.Sprintf("Unexpected status code: %d", res.StatusCode))
+	}
+
+	var pkgsInfo PackagesInfo
+	json.NewDecoder(res.Body).Decode(&pkgsInfo)
+
+	return pkgsInfo, nil
+}
+
+func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
+	var packages []PackageInfo
+
+	offset := 0
+	for {
+		pkgsInfo, err := depo.packagesInfo(pkgName, offset)
+
+		if err != nil {
+			return nil, err
+		}
+
+		packages = append(packages, pkgsInfo.PackageList...)
+
+		if pkgsInfo.RangeEnd+1 >= pkgsInfo.TotalCount {
+			break
+		}
+
+		offset += pkgsInfo.RangeEnd - pkgsInfo.RangeStart
+	}
+
+	var versions []string
+	for _, pkg := range packages {
+		versions = append(versions, pkg.Version)
+	}
+
+	return versions, nil
+}

--- a/hab/hab_test.go
+++ b/hab/hab_test.go
@@ -211,6 +211,46 @@ func TestPackagesInfoFromName(t *testing.T) {
 			packageName: "foo/test",
 			responses: []ResponseData{
 				PackagesInfo{
+					RangeStart: 0,
+					RangeEnd:   4,
+					TotalCount: 3,
+					PackageList: []PackageInfo{
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.1",
+							Release: "20170524100001",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.1",
+							Release: "20170524100002",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.2",
+							Release: "20170524100003",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.1.0",
+							Release: "20170524100004",
+						},
+					},
+				},
+			},
+			expected:      []string{"0.0.1", "0.0.2", "0.1.0"},
+			statusCode:    200,
+			httpError:     nil,
+			expectedError: nil,
+		},
+		{
+			packageName: "foo/test",
+			responses: []ResponseData{
+				PackagesInfo{
 					RangeStart:  0,
 					RangeEnd:    0,
 					TotalCount:  0,

--- a/hab/hab_test.go
+++ b/hab/hab_test.go
@@ -1,0 +1,247 @@
+package hab
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var TEST_HAB_URL = "http://foo.com/v1/depot"
+
+type testData struct {
+	packageName   string
+	packages      []PackagesInfo
+	expected      []string
+	statusCode    int
+	httpError     error
+	expectedError error
+}
+
+func makeFakeHTTPClient(t *testing.T, data testData) *http.Client {
+	count := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pkgsInfo := data.packages[count]
+		JSON, err := json.Marshal(pkgsInfo)
+
+		count += 1
+
+		if err != nil {
+			t.Fatalf("Unable to Marshal JSON for PackagesInfo: %v", err)
+		}
+
+		w.WriteHeader(data.statusCode)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, string(JSON))
+	}))
+
+	transport := &http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			expectedUrl := fmt.Sprintf("%s/pkgs/%s", TEST_HAB_URL, data.packageName)
+			if !strings.HasPrefix(req.URL.String(), expectedUrl) {
+				t.Errorf("Requested URL is %s, but it should start with %s", req.URL, expectedUrl)
+			}
+			return url.Parse(server.URL)
+		},
+	}
+
+	return &http.Client{Transport: transport}
+}
+
+func TestPackagesInfoFromName(t *testing.T) {
+	tests := []testData{
+		{
+			packageName: "foo/test",
+			packages: []PackagesInfo{
+				PackagesInfo{
+					RangeStart: 0,
+					RangeEnd:   4,
+					TotalCount: 3,
+					PackageList: []PackageInfo{
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.1",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.2",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.1.0",
+						},
+					},
+				},
+			},
+			expected:      []string{"0.0.1", "0.0.2", "0.1.0"},
+			statusCode:    200,
+			httpError:     nil,
+			expectedError: nil,
+		},
+		{
+			packageName: "foo/test",
+			packages: []PackagesInfo{
+				PackagesInfo{
+					RangeStart: 0,
+					RangeEnd:   4,
+					TotalCount: 5,
+					PackageList: []PackageInfo{
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.1",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.2",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.1.0",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.1.1",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+			expected:      []string{"0.0.1", "0.0.2", "0.1.0", "0.1.1", "1.0.0"},
+			statusCode:    200,
+			httpError:     nil,
+			expectedError: nil,
+		},
+		{
+			packageName: "foo/test",
+			packages: []PackagesInfo{
+				PackagesInfo{
+					RangeStart: 0,
+					RangeEnd:   4,
+					TotalCount: 8,
+					PackageList: []PackageInfo{
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.1",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.0.2",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.1.0",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "0.1.1",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "1.0.0",
+						},
+					},
+				},
+				PackagesInfo{
+					RangeStart: 5,
+					RangeEnd:   9,
+					TotalCount: 8,
+					PackageList: []PackageInfo{
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "1.0.1",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "1.1.0",
+						},
+						{
+							Origin:  "foo",
+							Name:    "test",
+							Version: "2.0.0",
+						},
+					},
+				},
+			},
+			expected:      []string{"0.0.1", "0.0.2", "0.1.0", "0.1.1", "1.0.0", "1.0.1", "1.1.0", "2.0.0"},
+			statusCode:    200,
+			httpError:     nil,
+			expectedError: nil,
+		},
+		{
+			packageName: "foo/test",
+			packages: []PackagesInfo{
+				PackagesInfo{
+					RangeStart:  0,
+					RangeEnd:    0,
+					TotalCount:  0,
+					PackageList: []PackageInfo{},
+				},
+			},
+			expected:      nil,
+			statusCode:    404,
+			httpError:     nil,
+			expectedError: errors.New("Package not found"),
+		},
+		{
+			packageName: "foo/test",
+			packages: []PackagesInfo{
+				PackagesInfo{
+					RangeStart:  0,
+					RangeEnd:    0,
+					TotalCount:  0,
+					PackageList: []PackageInfo{},
+				},
+			},
+			expected:      nil,
+			statusCode:    500,
+			httpError:     nil,
+			expectedError: errors.New("Unexpected status code: 500"),
+		},
+	}
+
+	for _, test := range tests {
+		http := makeFakeHTTPClient(t, test)
+		testDepot := &depot{TEST_HAB_URL, http}
+
+		results, err := testDepot.PackageVersionsFromName(test.packageName)
+
+		if test.expectedError == nil && err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if test.expectedError != nil {
+			if reflect.TypeOf(err) != reflect.TypeOf(test.expectedError) {
+				t.Fatalf("Expected error type: %v, actual %v", reflect.TypeOf(test.expectedError), reflect.TypeOf(err))
+			} else if err.Error() != test.expectedError.Error() {
+				t.Fatalf("Expected error message %v, actual %v", test.expectedError, err)
+			}
+		} else {
+			if !reflect.DeepEqual(results, test.expected) {
+				t.Errorf("Get versions %v, but expected %v", results, test.expected)
+			}
+		}
+	}
+}

--- a/hab/hab_test.go
+++ b/hab/hab_test.go
@@ -236,11 +236,11 @@ func TestPackagesInfoFromName(t *testing.T) {
 			if reflect.TypeOf(err) != reflect.TypeOf(test.expectedError) {
 				t.Fatalf("Expected error type: %v, actual %v", reflect.TypeOf(test.expectedError), reflect.TypeOf(err))
 			} else if err.Error() != test.expectedError.Error() {
-				t.Fatalf("Expected error message %v, actual %v", test.expectedError, err)
+				t.Errorf("Expected error message %v, actual %v", test.expectedError, err)
 			}
 		} else {
 			if !reflect.DeepEqual(results, test.expected) {
-				t.Errorf("Get versions %v, but expected %v", results, test.expected)
+				t.Errorf("Expected versions %v, actual %v", test.expected, results)
 			}
 		}
 	}

--- a/sd-step.go
+++ b/sd-step.go
@@ -20,7 +20,7 @@ import (
 var VERSION string
 
 // HAB_DEPOT_URL is base url for public depot of habitat
-var HAB_DEPOT_URL = "https://willem.habitat.sh/v1/depot"
+const habDepotURL = "https://willem.habitat.sh/v1/depot"
 
 var habPath = "/opt/sd/bin/hab"
 var versionValidator = regexp.MustCompile(`^\d+(\.\d+)*$`)
@@ -103,7 +103,7 @@ func getPackageVersion(depot hab.Depot, pkgName, pkgVerExp string) (string, erro
 
 	foundVersions, err := depot.PackageVersionsFromName(pkgName)
 	if err != nil {
-		return "", errors.New(fmt.Sprintf("Failed to fetch package versions: %v", err))
+		return "", fmt.Errorf("Failed to fetch package versions: %v", err)
 	}
 
 	var versions []*semver.Version
@@ -168,11 +168,11 @@ func main() {
 
 				pkgName := c.Args().Get(0)
 
-				depot := hab.New(HAB_DEPOT_URL)
+				depot := hab.New(habDepotURL)
 				pkgVersion, err := getPackageVersion(depot, pkgName, pkgVerExp)
 
 				if err != nil {
-					failureExit(errors.New(fmt.Sprintf("Failed to get package version: %v", err)))
+					failureExit(fmt.Errorf("Failed to get package version: %v", err))
 				}
 
 				err = execHab(pkgName, pkgVersion, c.Args().Tail(), os.Stdout)

--- a/sd-step.go
+++ b/sd-step.go
@@ -19,6 +19,7 @@ import (
 // VERSION gets set by the build script via the LDFLAGS
 var VERSION string
 
+// HAB_DEPOT_URL is base url for public depot of habitat
 var HAB_DEPOT_URL = "https://willem.habitat.sh/v1/depot"
 
 var habPath = "/opt/sd/bin/hab"

--- a/sd-step.go
+++ b/sd-step.go
@@ -19,7 +19,7 @@ import (
 // VERSION gets set by the build script via the LDFLAGS
 var VERSION string
 
-// HAB_DEPOT_URL is base url for public depot of habitat
+// habDepotURL is base url for public depot of habitat
 const habDepotURL = "https://willem.habitat.sh/v1/depot"
 
 var habPath = "/opt/sd/bin/hab"

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -154,6 +154,13 @@ func TestGetPackageVersions(t *testing.T) {
 			depotError:        nil,
 			expectedError:     nil,
 		},
+		{
+			versionExpression: "1.2.0-beta",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.2.3-abc", "1.3.0", "2.0.0"},
+			expectedVersion:   "",
+			depotError:        nil,
+			expectedError:     errors.New("The specified version not found"),
+		},
 	}
 
 	for _, test := range tests {
@@ -166,7 +173,7 @@ func TestGetPackageVersions(t *testing.T) {
 
 		if test.expectedError != nil {
 			if reflect.TypeOf(err) != reflect.TypeOf(test.expectedError) {
-				t.Fatalf("Unknown error type: %v", reflect.TypeOf(err))
+				t.Fatalf("Expected error type %v, actual %v", reflect.TypeOf(test.expectedError), reflect.TypeOf(err))
 			} else if err.Error() != test.expectedError.Error() {
 				t.Errorf("Expected Error \"%s\", actual \"%s\"", test.expectedError.Error(), err.Error())
 			}

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -88,4 +90,90 @@ func TestHelperProcess(t *testing.T) {
 		}
 	}
 	os.Exit(255)
+}
+
+type depotMock struct {
+	versions []string
+	err      error
+}
+
+func (depo *depotMock) PackageVersionsFromName(pkgName string) ([]string, error) {
+	if depo.err != nil {
+		return nil, depo.err
+	}
+	return depo.versions, nil
+}
+
+func TestGetPackageVersions(t *testing.T) {
+	tests := []struct {
+		versionExpression string
+		foundVersions     []string
+		expectedVersion   string
+		depotError        error
+		expectedError     error
+	}{
+		{
+			versionExpression: "1.0.0",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.0.0", "2.0.0"},
+			expectedVersion:   "1.0.0",
+			depotError:        nil,
+			expectedError:     nil,
+		},
+		{
+			versionExpression: "^1.2.0",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.3.0", "2.0.0"},
+			expectedVersion:   "1.3.0",
+			depotError:        nil,
+			expectedError:     nil,
+		},
+		{
+			versionExpression: "~1.2.0",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.3.0", "2.0.0"},
+			expectedVersion:   "1.2.2",
+			depotError:        nil,
+			expectedError:     nil,
+		},
+		{
+			versionExpression: "",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.3.0", "2.0.0"},
+			expectedVersion:   "",
+			depotError:        nil,
+			expectedError:     nil,
+		},
+		{
+			versionExpression: "1.0.0",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.3.0", "2.0.0"},
+			expectedVersion:   "",
+			depotError:        errors.New("depot error"),
+			expectedError:     errors.New("Failed to fetch package versions: depot error"),
+		},
+		{
+			versionExpression: "~1.2.0",
+			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.2.3-abc", "1.3.0", "2.0.0"},
+			expectedVersion:   "1.2.2",
+			depotError:        nil,
+			expectedError:     nil,
+		},
+	}
+
+	for _, test := range tests {
+		depot := &depotMock{test.foundVersions, test.depotError}
+		version, err := getPackageVersion(depot, "foo/test", test.versionExpression)
+
+		if test.expectedError == nil && err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if test.expectedError != nil {
+			if reflect.TypeOf(err) != reflect.TypeOf(test.expectedError) {
+				t.Fatalf("Unknown error type: %v", reflect.TypeOf(err))
+			} else if err.Error() != test.expectedError.Error() {
+				t.Errorf("Expected Error \"%s\", actual \"%s\"", test.expectedError.Error(), err.Error())
+			}
+		} else {
+			if version != test.expectedVersion {
+				t.Errorf("Expected \"%s\", actual \"%s\"", test.expectedVersion, version)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Now, sd-step command accepts only the exact version number for a habitat package but we want to specify the version number more flexibly.So I added this feature to sd-step.

It seems that `hab` command doesn't have appropriate sub commands or options to get all versions for a package, so this feature use habitat api to get versions for a package (but I don't know that we can use it...).

This works like this:
```
$ sd-step exec core/git git clone https://github.com/screwdriver-cd/sd-step.git --pkg-version ^2.7.4
```

I confirmed this feature in some commands.

if `pkg-version` option is not passed, it will use latest version as in the past.
```
$ sudo ./sd-step exec "core/git" "git --version"
git version 2.10.0
```
if semver expression is passed for `pkg-version` option, it works correctly.
```
$ sudo ./sd-step  exec --pkg-version "~2.7.0" core/git "git --version"
git version 2.7.4
```
```
$ sudo ./sd-step  exec --pkg-version "^2.7.0" core/git "git --version"
git version 2.10.0
```
if the exact version is passed for `pkg-version` option, it will use latest version as in the past.
```
$ sudo ./sd-step  exec --pkg-version "2.7.4" core/git "git --version"
git version 2.7.4
```
if the specified version is not found, it occurres error and exit.
```
$ sudo ./sd-step  exec --pkg-version "2.7.0" core/git "git --version"
ERROR: Failed to get package version: The specified version not found
```
