### PR TITLE
feat: Build darwin/amd64 binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,11 @@
+builds:
+  - binary: sd-step
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+
+archive:
+  format: binary
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -20,14 +20,12 @@ jobs:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - get: go get -t ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - build: go build -a -o sd-step
-            - get-bzip2: apt-get update && apt-get install -y --no-install-recommends bzip2
             - tag: ./ci/git-tag.sh
-            - release: ./ci/git-release.sh
+            - release: |
+                rm -f ./VERSION
+                curl -sL https://git.io/goreleaser | bash
         secrets:
             # Pushing tags to Git
             - GIT_KEY
             # Pushing releases to GitHub
             - GITHUB_TOKEN
-        environment:
-            RELEASE_FILE: sd-step


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We'd like to build iOS apps in MacOS VMs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Build and release for 64-bit macos. This PR uses goreleaser, see https://github.com/screwdriver-cd/log-service/pull/12 .

I have created related PRs to log-service, meta-cli, launcher. Please merge them at the same time, because the Dockerfile of launcher depends on the filname uploaded to GitHub Release.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Use jenkins executor for macos node : https://github.com/screwdriver-cd/executor-j5s/pull/12