### PR TITLE
fix: goreleaser validation error while deploying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,12 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Generated while deploying
+
+/ci/
+/VERSION
+
+# goreleaser
+
+/dist/

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -22,7 +22,6 @@ jobs:
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - tag: ./ci/git-tag.sh
             - release: |
-                rm -f ./VERSION
                 curl -sL https://git.io/goreleaser | bash
         secrets:
             # Pushing tags to Git


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Fix the ci error commented at https://github.com/screwdriver-cd/meta-cli/pull/8#pullrequestreview-56435737 . The error was caused by https://github.com/screwdriver-cd/sd-step/pull/4 .

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The goreleaser exits with error if there are uncommitted git changes.

I added the ci directory and VERSION file, distdirectory to the .gitignore. They are generated during the build.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- The error caused by https://github.com/screwdriver-cd/sd-step/pull/4
- Build Log https://cd.screwdriver.cd/pipelines/150/builds/8998
