### PR TITLE
fix(666): Execute sudo command if necessary

### DIFF
--- a/sd-step.go
+++ b/sd-step.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/user"
 	"regexp"
 	"runtime/debug"
 	"sort"
@@ -77,6 +78,11 @@ func execHab(pkgName string, pkgVersion string, command []string, output io.Writ
 	}
 
 	installCmd := []string{habPath, "pkg", "install", pkg, ">/dev/null"}
+	if u, userErr := user.Current(); userErr != nil || u.Uid != "0" {
+		// execute sudo command if not root user
+		installCmd = append([]string{"sudo"}, installCmd...)
+	}
+
 	unwrappedInstallCommand := strings.Join(installCmd, " ")
 	installErr := runCommand(unwrappedInstallCommand, output)
 	if installErr != nil {

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -26,7 +26,7 @@ func TestRunCommand(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 
 	stdout := new(bytes.Buffer)
-	err := runCommand("hab pkg install foo/bar", stdout)
+	err := runCommand("sudo hab pkg install foo/bar", stdout)
 	expected := "run hab pkg install\n"
 	if err != nil {
 		t.Errorf("runCommand error = %q, should be nil", err)
@@ -77,15 +77,16 @@ func TestHelperProcess(t *testing.T) {
 			break
 		}
 	}
-	if len(args) >= 4 && args[1] == "pkg" {
-		switch args[2] {
-		case "install":
+
+	if len(args) >= 4 {
+		if args[0] == "sudo" && args[3] == "install" ||
+			args[0] != "sudo" && args[2] == "install" {
 			fmt.Println("run hab pkg install")
 			return
-		case "exec":
+		} else if args[2] == "exec" {
 			fmt.Println("run hab pkg exec")
 			return
-		default:
+		} else {
 			os.Exit(255)
 		}
 	}


### PR DESCRIPTION
I fixed the issue described on screwdriver-cd/screwdriver#666
`hab install` command will be executed with sudo if a current user isn't root.