### PR TITLE
fix: Clone from toolbox for git scripts

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -17,7 +17,7 @@ jobs:
 
     deploy:
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - get: go get -t ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - tag: ./ci/git-tag.sh


### PR DESCRIPTION
Using the git-tag script from /toolbox repo to pull in the new git fingerprint
https://github.com/screwdriver-cd/screwdriver/issues/729