### PR TITLE
fix: fix json key name

### DIFF
--- a/hab/hab.go
+++ b/hab/hab.go
@@ -13,7 +13,7 @@ type PackagesInfo struct {
 	RangeStart  int           `json:"range_start"`
 	RangeEnd    int           `json:"range_end"`
 	TotalCount  int           `json:"total_count"`
-	PackageList []PackageInfo `json:"package_list"`
+	PackageList []PackageInfo `json:"data"`
 }
 
 // PackageInfo is package info in pkgs response


### PR DESCRIPTION
## Context
Because of change of habitat's response, sd-step cannot parse habitat's response json.
For that reason, sd-step cannot execute command when pkgVersion is set.
<img width="621" alt="2017-11-01 12 56 43" src="https://user-images.githubusercontent.com/8113204/32259484-3148b880-bf04-11e7-97c3-d99a756d7484.png">

## Objective
Fix json key to parse latest habitat's response json.

## Reference
An example of habitat's response:
https://willem.habitat.sh/v1/depot/pkgs/core/node?range=0