### PR TITLE
fix: Install from the specified release channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # sd-step
+[![Build Status][build-image]][build-url]
+[![Latest Release][version-image]][version-url]
+[![Go Report Card][goreport-image]][goreport-url]
+
+> Wrapper command of habitat for Screwdriver
+
+## Usage
+
+```bash
+$ go get github.com/screwdriver-cd/sd-step
+$ cd $GOPATH/src/github.com/screwdriver-cd/sd-step
+$ go build -a -o sd-step
+$ ./sd-step --help
+NAME:
+   sd-step - wrapper command of habitat for Screwdriver
+
+USAGE:
+   sd-step command arguments [options]
+
+VERSION:
+   0.0.0
+
+COMMANDS:
+     exec     Install and exec habitat package with pkg_name and command...
+     help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --pkg-version value  Package version which also accepts semver expression
+   --hab-channel value  Install from the specified release channel (default: "stable")
+   --help, -h           show help
+   --version, -v        print the version
+
+COPYRIGHT:
+   (c) 2017 Yahoo Inc.
+$ ./sd-step exec core/node "node -v"
+v8.9.0
+$ ./sd-step exec --pkg-version "~6.11.0" core/node "node -v"
+v6.11.5
+$ ./sd-step exec --pkg-version "^6.0.0" core/node "node -v"
+v6.11.5
+$ ./sd-step exec --pkg-version "4.2.6" core/node "node -v"
+v4.2.6
+$ ./sd-step exec --pkg-version "~6.9.0" --hab-channel "unstable" core/node "node -v"
+v6.9.5
+```
+
+## Testing
+
+```bash
+$ go get github.com/screwdriver-cd/sd-step
+$ go test -cover github.com/screwdriver-cd/sd-step/...
+```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[version-image]: https://img.shields.io/github/tag/screwdriver-cd/sd-step.svg
+[version-url]: https://github.com/screwdriver-cd/sd-step/releases
+[build-image]: https://cd.screwdriver.cd/pipelines/150/badge
+[build-url]: https://cd.screwdriver.cd/pipelines/150
+[goreport-image]: https://goreportcard.com/badge/github.com/Screwdriver-cd/sd-step
+[goreport-url]: https://goreportcard.com/report/github.com/Screwdriver-cd/sd-step

--- a/hab/hab.go
+++ b/hab/hab.go
@@ -18,15 +18,16 @@ type PackagesInfo struct {
 
 // PackageInfo is package info in pkgs response
 type PackageInfo struct {
-	Origin  string `json:"origin"`
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Release string `json:"release"`
+	Origin   string   `json:"origin"`
+	Name     string   `json:"name"`
+	Version  string   `json:"version"`
+	Release  string   `json:"release"`
+	Channels []string `json:"channels"`
 }
 
 // Depot for hab
 type Depot interface {
-	PackageVersionsFromName(pkgName string) ([]string, error)
+	PackageVersionsFromName(pkgName string, habChannel string) ([]string, error)
 }
 
 type depot struct {
@@ -67,7 +68,7 @@ func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) 
 }
 
 // PackageVersionsFromName fetch all versions from depot
-func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
+func (depo *depot) PackageVersionsFromName(pkgName string, habChannel string) ([]string, error) {
 	var packages []PackageInfo
 
 	offset := 0
@@ -93,8 +94,13 @@ func (depo *depot) PackageVersionsFromName(pkgName string) ([]string, error) {
 		if foundVersions[pkg.Version] {
 			continue
 		}
-		versions = append(versions, pkg.Version)
-		foundVersions[pkg.Version] = true
+		for _, channel := range pkg.Channels {
+			if channel == habChannel {
+				versions = append(versions, pkg.Version)
+				foundVersions[pkg.Version] = true
+				break
+			}
+		}
 	}
 
 	return versions, nil

--- a/hab/hab_test.go
+++ b/hab/hab_test.go
@@ -18,6 +18,7 @@ type ResponseData interface{}
 
 type testData struct {
 	packageName   string
+	channelName   string
 	responses     []ResponseData
 	expected      []string
 	statusCode    int
@@ -74,6 +75,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 	tests := []testData{
 		{
 			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart: 0,
@@ -81,19 +83,22 @@ func TestPackagesInfoFromName(t *testing.T) {
 					TotalCount: 3,
 					PackageList: []PackageInfo{
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.1",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.2",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.2",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.1.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.0",
+							Channels: []string{"stable"},
 						},
 					},
 				},
@@ -105,6 +110,42 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "unstable",
+			responses: []ResponseData{
+				PackagesInfo{
+					RangeStart: 0,
+					RangeEnd:   4,
+					TotalCount: 3,
+					PackageList: []PackageInfo{
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Channels: []string{"stable"},
+						},
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.2",
+							Channels: []string{"stable"},
+						},
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.0",
+							Channels: []string{"stable"},
+						},
+					},
+				},
+			},
+			expected:      nil,
+			statusCode:    200,
+			httpError:     nil,
+			expectedError: nil,
+		},
+		{
+			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart: 0,
@@ -112,29 +153,34 @@ func TestPackagesInfoFromName(t *testing.T) {
 					TotalCount: 5,
 					PackageList: []PackageInfo{
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.1",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.2",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.2",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.1.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.0",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.1.1",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.1",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "1.0.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "1.0.0",
+							Channels: []string{"stable"},
 						},
 					},
 				},
@@ -146,6 +192,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart: 0,
@@ -153,29 +200,34 @@ func TestPackagesInfoFromName(t *testing.T) {
 					TotalCount: 8,
 					PackageList: []PackageInfo{
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.1",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.2",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.2",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.1.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.0",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.1.1",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.1",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "1.0.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "1.0.0",
+							Channels: []string{"stable"},
 						},
 					},
 				},
@@ -185,19 +237,22 @@ func TestPackagesInfoFromName(t *testing.T) {
 					TotalCount: 8,
 					PackageList: []PackageInfo{
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "1.0.1",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "1.0.1",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "1.1.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "1.1.0",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "2.0.0",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "2.0.0",
+							Channels: []string{"stable"},
 						},
 					},
 				},
@@ -209,6 +264,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart: 0,
@@ -216,28 +272,32 @@ func TestPackagesInfoFromName(t *testing.T) {
 					TotalCount: 3,
 					PackageList: []PackageInfo{
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.1",
-							Release: "20170524100001",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Release:  "20170524100001",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.1",
-							Release: "20170524100002",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Release:  "20170524100002",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.0.2",
-							Release: "20170524100003",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.2",
+							Release:  "20170524100003",
+							Channels: []string{"stable"},
 						},
 						{
-							Origin:  "foo",
-							Name:    "test",
-							Version: "0.1.0",
-							Release: "20170524100004",
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.0",
+							Release:  "20170524100004",
+							Channels: []string{"stable"},
 						},
 					},
 				},
@@ -249,6 +309,52 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "stable",
+			responses: []ResponseData{
+				PackagesInfo{
+					RangeStart: 0,
+					RangeEnd:   4,
+					TotalCount: 3,
+					PackageList: []PackageInfo{
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Release:  "20170524100001",
+							Channels: []string{"unstable"},
+						},
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.1",
+							Release:  "20170524100002",
+							Channels: []string{"stable"},
+						},
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.0.2",
+							Release:  "20170524100003",
+							Channels: []string{"unstable"},
+						},
+						{
+							Origin:   "foo",
+							Name:     "test",
+							Version:  "0.1.0",
+							Release:  "20170524100004",
+							Channels: []string{"stable"},
+						},
+					},
+				},
+			},
+			expected:      []string{"0.0.1", "0.1.0"},
+			statusCode:    200,
+			httpError:     nil,
+			expectedError: nil,
+		},
+		{
+			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart:  0,
@@ -264,6 +370,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart:  0,
@@ -279,6 +386,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				PackagesInfo{
 					RangeStart:  0,
@@ -294,6 +402,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 		},
 		{
 			packageName: "foo/test",
+			channelName: "stable",
 			responses: []ResponseData{
 				"corrupted json data",
 			},
@@ -308,7 +417,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 		http := makeFakeHTTPClient(t, test)
 		testDepot := &depot{testHabURL, http}
 
-		results, err := testDepot.PackageVersionsFromName(test.packageName)
+		results, err := testDepot.PackageVersionsFromName(test.packageName, test.channelName)
 
 		if test.expectedError == nil && err != nil {
 			t.Fatalf("Unexpected error: %v", err)

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -50,7 +50,7 @@ func TestExecHab(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	execCommand = fakeExecCommand
 	defer func() { execCommand = exec.Command }()
-	err := execHab("foo/bar", "2.2.2", []string{"foo", "bar", "foobar"}, stdout)
+	err := execHab("foo/bar", "2.2.2", "stable", []string{"foo", "bar", "foobar"}, stdout)
 	if err != nil {
 		t.Errorf("execHab error = %q, should be nil", err)
 	}
@@ -98,7 +98,7 @@ type depotMock struct {
 	err      error
 }
 
-func (depo *depotMock) PackageVersionsFromName(pkgName string) ([]string, error) {
+func (depo *depotMock) PackageVersionsFromName(pkgName string, habChannel string) ([]string, error) {
 	if depo.err != nil {
 		return nil, depo.err
 	}
@@ -166,7 +166,7 @@ func TestGetPackageVersions(t *testing.T) {
 
 	for _, test := range tests {
 		depot := &depotMock{test.foundVersions, test.depotError}
-		version, err := getPackageVersion(depot, "foo/test", test.versionExpression)
+		version, err := getPackageVersion(depot, "foo/test", test.versionExpression, "stable")
 
 		if test.expectedError == nil && err != nil {
 			t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
## Context
Habitat packages have release channel, and `hab pkg install` command install packages from default channel `stable`.
However, the method `PackageVersionsFromName` returns specified name packages in all release channel. Therefore, if a package whose version is matched pkgVersionExp is not in stable channel, sd_step failed like below.
<img width="612" alt="2017-11-07 14 14 46" src="https://user-images.githubusercontent.com/8113204/32478130-3a6a0556-c3c6-11e7-9b15-81048f924a27.png">

## Objective
- Add an option `hab-channel` to install habitat packages from specified release channel.
- Fix `PackageVersionsFromName` to search package versions from specified release channel.

## References
An example of habitat's response:
https://willem.habitat.sh/v1/depot/pkgs/core/node?range=0
`hab pkg install` reference:
https://www.habitat.sh/docs/habitat-cli/#hab-pkg-install