### PR TITLE
Reduce habitat API call

### DIFF
--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -146,7 +146,7 @@ func TestGetPackageVersions(t *testing.T) {
 			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.3.0", "2.0.0"},
 			expectedVersion:   "",
 			depotError:        errors.New("depot error"),
-			expectedError:     errors.New("Failed to fetch package versions: depot error"),
+			expectedError:     errors.New("The specified version not found"),
 		},
 		{
 			versionExpression: "~1.2.0",


### PR DESCRIPTION
This PR fixes screwdriver-cd/screwdriver#1163.

When a user execute sd-step, it tries to install habitat package every time.
I fixed that by checking if a package is installed or not with hab pkg path and installing the package only when non-existent.
Note:
hab pkg path exits with zero when a package exists, otherwise non-zero.
Diff with -w option is recommended: https://github.com/screwdriver-cd/sd-step/pull/11/files?w=1