### PR TITLE
Reduce api call

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,3 @@
-workflow:
-    - deploy
-
 shared:
     image: golang
     environment:
@@ -8,6 +5,7 @@ shared:
 
 jobs:
     main:
+        requires: [~commit, ~pr]
         steps:
             - get: go get -t ./...
             - vet: go vet ./...
@@ -16,6 +14,7 @@ jobs:
             - build: go build -a -o sd-step
 
     deploy:
+        requires: main
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - get: go get -t ./...

--- a/sd-step.go
+++ b/sd-step.go
@@ -77,16 +77,21 @@ func execHab(pkgName string, pkgVersion string, habChannel string, command []str
 		return verErr
 	}
 
-	installCmd := []string{habPath, "pkg", "install", pkg, "-c", habChannel, ">/dev/null"}
-	if u, userErr := user.Current(); userErr != nil || u.Uid != "0" {
-		// execute sudo command if not root user
-		installCmd = append([]string{"sudo"}, installCmd...)
-	}
+	checkCmd := habPath + " pkg path " + pkg + " >/dev/null 2>&1"
+	installed := runCommand(checkCmd, output)
 
-	unwrappedInstallCommand := strings.Join(installCmd, " ")
-	installErr := runCommand(unwrappedInstallCommand, output)
-	if installErr != nil {
-		return installErr
+	if installed != nil {
+		installCmd := []string{habPath, "pkg", "install", pkg, "-c", habChannel, ">/dev/null"}
+		if u, userErr := user.Current(); userErr != nil || u.Uid != "0" {
+			// execute sudo command if not root user
+			installCmd = append([]string{"sudo"}, installCmd...)
+		}
+
+		unwrappedInstallCommand := strings.Join(installCmd, " ")
+		installErr := runCommand(unwrappedInstallCommand, output)
+		if installErr != nil {
+			return installErr
+		}
 	}
 
 	execCmd := []string{habPath, "pkg", "exec", pkg}


### PR DESCRIPTION
This PR fixes screwdriver-cd/screwdriver#1163.

When a user execute sd-step, it tries to install habitat package every time.
I fixed that by checking if a package is installed or not with hab pkg path and installing the package only when non-existent.
Note:
hab pkg path exits with zero when a package exists, otherwise non-zero.
Diff with -w option is recommended: https://github.com/screwdriver-cd/sd-step/pull/11/files?w=1