### PR TITLE
fix: habitat api slow response

### DIFF
--- a/hab/hab.go
+++ b/hab/hab.go
@@ -37,7 +37,7 @@ type depot struct {
 
 // New returns a new depot object
 func New(baseURL string) Depot {
-	return &depot{baseURL, &http.Client{Timeout: 10 * time.Second}}
+	return &depot{baseURL, &http.Client{Timeout: 20 * time.Second}}
 }
 
 // packagesInfo fetch packages info from depot


### PR DESCRIPTION
Habitat API's are getting slower. We do use pagination, but API does not have  way to customize total count. API calls with base page size are timing out when trying to find versions