### PR TITLE
convert to go modules, fix linters issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 ```bash
 $ go get github.com/screwdriver-cd/sd-step
-$ cd $GOPATH/src/github.com/screwdriver-cd/sd-step
-$ go build -a -o sd-step
 $ ./sd-step --help
 NAME:
    sd-step - wrapper command of habitat for Screwdriver

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,2 @@
+// Sd-step is a wrapper command of habitat for Screwdriver.
+package main

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/screwdriver-cd/sd-step
+
+go 1.13
+
+require (
+	github.com/Masterminds/semver v1.5.0
+	github.com/urfave/cli v1.22.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
+github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/hab/doc.go
+++ b/hab/doc.go
@@ -1,0 +1,3 @@
+// Package hab provides utility functions for working with Habitat
+// https://www.habitat.sh.
+package hab

--- a/hab/hab.go
+++ b/hab/hab.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-// PackagesInfo is response from depotj
+// PackagesInfo is response from depot.
 type PackagesInfo struct {
 	RangeStart  int           `json:"range_start"`
 	RangeEnd    int           `json:"range_end"`
@@ -16,7 +16,7 @@ type PackagesInfo struct {
 	PackageList []PackageInfo `json:"data"`
 }
 
-// PackageInfo is package info in pkgs response
+// PackageInfo is package info in pkgs response.
 type PackageInfo struct {
 	Origin   string   `json:"origin"`
 	Name     string   `json:"name"`
@@ -25,7 +25,7 @@ type PackageInfo struct {
 	Channels []string `json:"channels"`
 }
 
-// Depot for hab
+// Depot for hab.
 type Depot interface {
 	PackageVersionsFromName(pkgName string, habChannel string) ([]string, error)
 }
@@ -35,7 +35,7 @@ type depot struct {
 	client  *http.Client
 }
 
-// New returns a new depot object
+// New returns a new depot object.
 func New(baseURL string) Depot {
 	return &depot{baseURL, &http.Client{Timeout: 20 * time.Second}}
 }
@@ -52,9 +52,10 @@ func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) 
 	defer res.Body.Close()
 
 	if res.StatusCode == 404 {
-		return PackagesInfo{}, errors.New("Package not found")
-	} else if res.StatusCode/100 != 2 {
-		return PackagesInfo{}, fmt.Errorf("Unexpected status code: %d", res.StatusCode)
+		return PackagesInfo{}, errors.New("package not found")
+	}
+	if res.StatusCode/100 != 2 {
+		return PackagesInfo{}, fmt.Errorf("unexpected status code: %d", res.StatusCode)
 	}
 
 	var pkgsInfo PackagesInfo
@@ -67,7 +68,7 @@ func (depo *depot) packagesInfo(pkgName string, from int) (PackagesInfo, error) 
 	return pkgsInfo, nil
 }
 
-// PackageVersionsFromName fetch all versions from depot
+// PackageVersionsFromName fetches all versions from depot.
 func (depo *depot) PackageVersionsFromName(pkgName string, habChannel string) ([]string, error) {
 	var packages []PackageInfo
 

--- a/hab/hab_test.go
+++ b/hab/hab_test.go
@@ -67,8 +67,12 @@ func makeFakeHTTPClient(t *testing.T, data testData) *http.Client {
 	return &http.Client{Transport: transport}
 }
 
+type fakeStruct struct{}
+
 func jsonError(JSON string) error {
-	return json.Unmarshal([]byte(JSON), nil)
+	// "dummy" object to avoid `go vet` error when passing nil
+	dummy := &fakeStruct{}
+	return json.Unmarshal([]byte(JSON), dummy)
 }
 
 func TestPackagesInfoFromName(t *testing.T) {
@@ -402,7 +406,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 			expected:      nil,
 			statusCode:    404,
 			httpError:     nil,
-			expectedError: errors.New("Package not found"),
+			expectedError: errors.New("package not found"),
 		},
 		{
 			packageName: "foo/test",
@@ -418,7 +422,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 			expected:      nil,
 			statusCode:    500,
 			httpError:     nil,
-			expectedError: errors.New("Unexpected status code: 500"),
+			expectedError: errors.New("unexpected status code: 500"),
 		},
 		{
 			packageName: "foo/test",
@@ -434,7 +438,7 @@ func TestPackagesInfoFromName(t *testing.T) {
 			expected:      nil,
 			statusCode:    500,
 			httpError:     nil,
-			expectedError: errors.New("Unexpected status code: 500"),
+			expectedError: errors.New("unexpected status code: 500"),
 		},
 		{
 			packageName: "foo/test",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,17 +7,17 @@ jobs:
     main:
         requires: [~commit, ~pr]
         steps:
-            - get: go get -t ./...
+            - modverify: go mod verify
             - vet: go vet ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - test: go test ./...
-            - build: go build -a -o sd-step
+            - build: go install -v ./...
 
     deploy:
         requires: main
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - get: go get -t ./...
+            - get: go install -v ./...
             - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
             - tag: ./ci/git-tag.sh
             - release: |

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,8 +8,17 @@ jobs:
         requires: [~commit, ~pr]
         steps:
             - modverify: go version; go mod verify
+            - gofmt: |
+                gofmtOutput=$(gofmt -l .)
+                if [ -z "${gofmtOutput}" ]; then
+                    echo "OK"
+                else
+                    echo "gofmt violations in the following file(s):"
+                    echo "${gofmtOutput}\n"
+                    gofmt -d .
+                    exit 1
+                fi
             - vet: go vet ./...
-            - gofmt: gofmt -l .
             - build: go install -v ./...
             - test: go test -v ./...
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,18 +7,17 @@ jobs:
     main:
         requires: [~commit, ~pr]
         steps:
-            - modverify: go mod verify
+            - modverify: go version; go mod verify
             - vet: go vet ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
-            - test: go test ./...
+            - gofmt: gofmt -l .
             - build: go install -v ./...
+            - test: go test -v ./...
 
     deploy:
         requires: main
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - get: go install -v ./...
-            - gofmt: "find . -name '*.go' | xargs gofmt -s -w"
+            - build: go install -v ./...
             - tag: ./ci/git-tag.sh
             - release: |
                 curl -sL https://git.io/goreleaser | bash

--- a/sd-step.go
+++ b/sd-step.go
@@ -10,7 +10,7 @@ import (
 	"os/user"
 	"regexp"
 	"runtime/debug"
-	"sort"
+ 	  "sort"
 	"strings"
 
 	"github.com/Masterminds/semver"

--- a/sd-step.go
+++ b/sd-step.go
@@ -10,7 +10,7 @@ import (
 	"os/user"
 	"regexp"
 	"runtime/debug"
- 	  "sort"
+	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver"

--- a/sd-step.go
+++ b/sd-step.go
@@ -18,10 +18,10 @@ import (
 	"github.com/urfave/cli"
 )
 
-// VERSION gets set by the build script via the LDFLAGS
+// VERSION gets set by the build script via the LDFLAGS.
 var VERSION string
 
-// habDepotURL is base url for public depot of habitat
+// habDepotURL is base url for public depot of habitat.
 const habDepotURL = "https://willem.habitat.sh/v1/depot"
 
 var habPath = "/opt/sd/bin/hab"
@@ -33,7 +33,7 @@ func successExit() {
 	os.Exit(0)
 }
 
-// failureExit exits process with 1
+// failureExit exits process with 1.
 func failureExit(err error) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
@@ -52,18 +52,18 @@ func finalRecover() {
 	successExit()
 }
 
-// translatePkgName translates the pkgName if pkgVersion is specified
+// translatePkgName translates the pkgName if pkgVersion is specified.
 func translatePkgName(pkgName string, pkgVersion string) (string, error) {
 	if pkgVersion == "" {
 		return pkgName, nil
-	} else if valid := versionValidator.MatchString(pkgVersion); valid == true {
-		return pkgName + "/" + pkgVersion, nil
-	} else {
-		return "", fmt.Errorf("%v is invalid version", pkgVersion)
 	}
+	if valid := versionValidator.MatchString(pkgVersion); valid {
+		return pkgName + "/" + pkgVersion, nil
+	}
+	return "", fmt.Errorf("%v is invalid version", pkgVersion)
 }
 
-// runCommand runs command
+// runCommand runs command.
 func runCommand(command string, output io.Writer) error {
 	cmd := execCommand("sh", "-c", command)
 	cmd.Stdout = output
@@ -71,7 +71,7 @@ func runCommand(command string, output io.Writer) error {
 	return cmd.Run()
 }
 
-// Check if package is installed
+// isPackageInstalled checks if the package is installed.
 func isPackageInstalled(pkgName string, pkgVersion string) bool {
 	var output io.Writer
 
@@ -87,7 +87,7 @@ func isPackageInstalled(pkgName string, pkgVersion string) bool {
 	return checkCmdResult == nil
 }
 
-// execHab installs habitat package and executes habitat command
+// execHab installs habitat package and executes habitat command.
 func execHab(pkgName string, pkgVersion string, habChannel string, command []string, output io.Writer) error {
 	pkg, verErr := translatePkgName(pkgName, pkgVersion)
 	if verErr != nil {
@@ -132,7 +132,7 @@ func getPackageVersion(depot hab.Depot, pkgName, pkgVerExp string, habChannel st
 			"Trying to fetch versions from installed packages...\n", err)
 		dirs, err := ioutil.ReadDir("/hab/pkgs/" + pkgName)
 		if err != nil {
-			return "", errors.New("The specified version not found")
+			return "", errors.New("the specified version not found")
 		}
 		for _, dir := range dirs {
 			foundVersions = append(foundVersions, dir.Name())
@@ -157,7 +157,7 @@ func getPackageVersion(depot hab.Depot, pkgName, pkgVerExp string, habChannel st
 	}
 
 	if len(versions) == 0 {
-		return "", errors.New("The specified version not found")
+		return "", errors.New("the specified version not found")
 	}
 
 	sort.Sort(sort.Reverse(semver.Collection(versions)))
@@ -219,7 +219,7 @@ func main() {
 					pkgVersion, err = getPackageVersion(depot, pkgName, pkgVerExp, habChannel)
 
 					if err != nil {
-						failureExit(fmt.Errorf("Failed to get package version: %v", err))
+						failureExit(fmt.Errorf("failed to get package version: %v", err))
 					}
 				}
 

--- a/sd-step_test.go
+++ b/sd-step_test.go
@@ -31,8 +31,8 @@ func TestRunCommand(t *testing.T) {
 	if err != nil {
 		t.Errorf("runCommand error = %q, should be nil", err)
 	}
-	if string(stdout.Bytes()) != expected {
-		t.Errorf("Expected '%v', actual '%v'", expected, string(stdout.Bytes()))
+	if s := stdout.String(); s != expected {
+		t.Errorf("Expected '%v', actual '%v'", expected, s)
 	}
 
 	stdout = new(bytes.Buffer)
@@ -41,8 +41,8 @@ func TestRunCommand(t *testing.T) {
 	if err != nil {
 		t.Errorf("runCommand error = %v, should be nil", err)
 	}
-	if string(stdout.Bytes()) != expected {
-		t.Errorf("Expected '%v', actual '%v'", expected, string(stdout.Bytes()))
+	if s := stdout.String(); s != expected {
+		t.Errorf("Expected '%v', actual '%v'", expected, s)
 	}
 }
 
@@ -54,8 +54,8 @@ func TestExecHab(t *testing.T) {
 	if err != nil {
 		t.Errorf("execHab error = %q, should be nil", err)
 	}
-	if string(stdout.Bytes()) != habExecResult {
-		t.Errorf("Expected %q, got %q", habExecResult, string(stdout.Bytes()))
+	if s := stdout.String(); s != habExecResult {
+		t.Errorf("Expected %q, got %q", habExecResult, s)
 	}
 }
 
@@ -146,7 +146,7 @@ func TestGetPackageVersions(t *testing.T) {
 			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.3.0", "2.0.0"},
 			expectedVersion:   "",
 			depotError:        errors.New("depot error"),
-			expectedError:     errors.New("The specified version not found"),
+			expectedError:     errors.New("the specified version not found"),
 		},
 		{
 			versionExpression: "~1.2.0",
@@ -160,7 +160,7 @@ func TestGetPackageVersions(t *testing.T) {
 			foundVersions:     []string{"0.0.1", "0.1.0", "1.1.9", "1.2.1", "1.2.2", "1.2.3-abc", "1.3.0", "2.0.0"},
 			expectedVersion:   "",
 			depotError:        nil,
-			expectedError:     errors.New("The specified version not found"),
+			expectedError:     errors.New("the specified version not found"),
 		},
 	}
 


### PR DESCRIPTION
PR converts repo to Go modules by adding `go.mod` file for easier development (build anywhere you check out, not necessarily under `$GOPATH/src`).  It also adds `doc.go` file for proper documentation and cleans up the linters issues (`golint` and `staticcheck`) and edits some comments. Also modifies and reorders the build steps and makes builds fail on `gofmt` violations - as in this test build: https://cd.screwdriver.cd/pipelines/150/builds/156365/steps/gofmt

/cc @jithine
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
